### PR TITLE
ci: remove deprecated lang version from golangci

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -97,4 +97,3 @@ run:
 linters-settings:
   gofumpt:
     extra-rules: true
-    lang-version: "1.21"


### PR DESCRIPTION
1. `linter.lang-version` is deprecated in favor of `run.go`
2. `run.go` defaults to the version in `go.mod` as per [docs](https://golangci-lint.run/usage/configuration/#run-configuration)